### PR TITLE
Ensure stan models retain explicit names

### DIFF
--- a/R/stan_model_cache.R
+++ b/R/stan_model_cache.R
@@ -17,7 +17,7 @@ get_explicit_stanmodel <- function(model_name) {
     }
     assign(
       model_name,
-      rstan::stan_model(file = stan_file, allow_undefined = TRUE),
+      rstan::stan_model(file = stan_file, model_name = model_name, allow_undefined = TRUE),
       envir = .stan_model_cache_explicit
     )
   }


### PR DESCRIPTION
## Summary
- ensure get_explicit_stanmodel() assigns compiled Stan models using the provided model name so cached objects retain expected identifiers

## Testing
- not run (Rscript unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68cbd3c8db388328a632162216336e8d